### PR TITLE
Match on Project and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # togxp
+
 Toggl to crm timesheet export script
+
+## Configuration
+
+* `Toggl.ApiKey` - Your Toggl API token, findable on your toggl [profile page](https://toggl.com/app/profile).
+* `Toggl.Workspace` - The Toggl workspace to target, to find visit the [dashboard](https://toggl.com/app/dashboard/me) for the workspace, and copy the number from the url
+* `Crm.Username` - User to log the time entries under on CRM, including domain
+* `Output.DefaultLocation` - Default location to output to if `--outfile` is passed without a parameter
+* `Projects` - Array of Toggl to CRM lookup rules, rules are evaluated in order and the first one that matches is used.
+
+### Lookup rules
+
+Each lookup rule can specify checks against the client, the project, or both. If both are specified they both need to match for the rule to be valid. If a rule specifies none, then it will match any time entry.
+
+You can either specify a Regex rule or a plain string rule. If you specify both the Regex rule will override the plain text rule.
+
+* `ClientRegex` - A regular expression to match against the name of the client for the toggl time entry.
+* `Client` - A string that needs to exactly match the name of the client.
+* `ProjectRegex` - A regular expression to match against the name of the project for the toggl time entry.
+* `Project` - A string that needs to exactly match the name of the client.
+
+Lookup rules then state how to log the information into CRM
+
+* `Order` - The ID of the Order to log against.
+* `Category` - The Category to use in the order, if one isn't stated in the toggl description.
+
+## Toggl Description parsing
+
+Case Ids and categories can be specified at the start of Toggl description. The case ID must start with `CAS-` (case specific). Categories must be wrapped inside square brackets (`[]`). The Case and category can be specified in either order, but they must be the first things in the description, and must only have whitespace between them.
+
+The remaining part of the description is used for the name of the time entry in CRM.

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ You can either specify a Regex rule or a plain string rule. If you specify both 
 * `ProjectRegex` - A regular expression to match against the name of the project for the toggl time entry.
 * `Project` - A string that needs to exactly match the name of the client.
 
-Lookup rules then state how to log the information into CRM
+Lookup rules then state how to log the information into CRM, all optional.
 
 * `Order` - The ID of the Order to log against.
+* `Opportunity` - The ID of the Opportunity to log against.
 * `Category` - The Category to use in the order, if one isn't stated in the toggl description.
 
 ## Toggl Description parsing

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can either specify a Regex rule or a plain string rule. If you specify both 
 * `ProjectRegex` - A regular expression to match against the name of the project for the toggl time entry.
 * `Project` - A string that needs to exactly match the name of the client.
 
-Lookup rules then state how to log the information into CRM, all optional.
+Lookup rules then state how to log the information into CRM. At least one of order or opportunity needs to specified.
 
 * `Order` - The ID of the Order to log against.
 * `Opportunity` - The ID of the Opportunity to log against.

--- a/config-example.json
+++ b/config-example.json
@@ -11,11 +11,10 @@
     },
     "Projects":[
         {
-            "TitleRegex": "<A Regex Expression>",
-            "Order": "<Order Id>",
-            "Category": "<Category>"
-        },{
-            "Title": "<A String>",
+            "ClientRegex": "<RegExp; Optional; Do not specify with Client>",
+            "Client": "<String; Optional; Do not specify with ClientRegex>",
+            "ProjectRegex": "<RegExp; Optional; Do not specify with Project>",
+            "Project": "<String; Optional; Do not specify with ProjectRegex>",
             "Order": "<Order Id>",
             "Category": "<Category>"
         }

--- a/config-example.json
+++ b/config-example.json
@@ -16,6 +16,7 @@
             "ProjectRegex": "<RegExp; Optional; Do not specify with Project>",
             "Project": "<String; Optional; Do not specify with ProjectRegex>",
             "Order": "<Order Id>",
+            "Opportunity": "<Opportunity Id>",
             "Category": "<Category>"
         }
     ]

--- a/index.js
+++ b/index.js
@@ -76,7 +76,8 @@ function getOrderAndCategoryForProject(project,client){
     for (config of PROJECT_CONFIGS){
         if ( CheckTest(config.Project,project) && CheckTest(config.Client,client) ){
             return {
-                order:config.order,
+                order:config.order||"",
+                opportunity:config.opportunity||"",
                 category:config.category
             }
         }
@@ -177,6 +178,7 @@ async function getFromToggle({since,until}){
             let config = getOrderAndCategoryForProject(r.project,r.client);
             order = config.order;
             defaultCat = config.category;
+            opportunity = config.opportunity
         } catch (e){
             console.error(`Cannot match project for "${r.project}", add to config to continue`);
             continue;
@@ -199,7 +201,7 @@ async function getFromToggle({since,until}){
             USERNAME,
             cas,
             order,
-            "", //Opportunity
+            opportunity, //Opportunity
             "", //Quote
             "" //Invoice
         ])

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ async function LoadConfig(){
     USERNAME = config.Crm.Username;
     DEFAULT_LOC = config.Output.DefaultLocation;
 
-    PROJECT_CONFIGS = config.Projects.map(input => {
+    PROJECT_CONFIGS = config.Projects.map((input,i) => {
         var copy = {...input};
         if ("ProjectRegex" in copy){
             copy.Project = new RegExp(input.ProjectRegex);
@@ -52,6 +52,9 @@ async function LoadConfig(){
         if ("ClientRegex" in copy){
             copy.Client = new RegExp(input.ClientRegex);
             delete copy.ClientRegex;
+        }
+        if(!("Order" in copy) && !("Opportunity" in copy)){
+            throw `Bad configuration, Rule {i} lacks either Order or Opportunity`;
         }
         return copy;
     });
@@ -76,9 +79,9 @@ function getOrderAndCategoryForProject(project,client){
     for (config of PROJECT_CONFIGS){
         if ( CheckTest(config.Project,project) && CheckTest(config.Client,client) ){
             return {
-                order:config.order||"",
-                opportunity:config.opportunity||"",
-                category:config.category
+                order:config.Order||"",
+                opportunity:config.Opportunity||"",
+                category:config.Category
             }
         }
     }


### PR DESCRIPTION
Adds the ability to match against toggl's Client field. Configuration entries can now specify a client, project, both, or none!
If both are specified the match logic is and'd together, so the time entry will have to match both the given project and client.

If none is specified then the entry is a catch all wild card. Since matching is done from top to bottom, only one catch all wild card should be used, and it should be placed at the bottom.

Also adds the ability to log against CRM Opportunities instead of just Orders. Lookup rules are required to have at least one of Order or Opportunity to work.